### PR TITLE
Fix web compile errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ bevy = { version = "0.15", default-features = false, features = [
   "sysinfo_plugin",
 ] }
 
-criterion = "0.5"
+criterion = { version = "0.5", default-features = false, features = ["plotters", "cargo_bench_support"]}
 
 [[bench]]
 name = "basic"


### PR DESCRIPTION
# Web Build Fixes

## Overview

This PR is divided in 2 parts:
- remove `criterion` "rayon" feature, that throw a compile-error when trying to build for a web target
- fix code errors 