### PR TITLE
Fix Android Runtime Error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,12 @@ bevy_seedling_macros = { path = "./seedling_macros", version = "0.3.0" }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 firewheel = { version = "0.3", features = ["wasm-bindgen"] }
 
+[target."cfg(target_os = \"android\")".dependencies.bevy]
+features = [
+  # bevy_seedling can't operate without the C++ shared stdlib on Android
+  "android_shared_stdcxx",
+]
+
 [dev-dependencies]
 bevy = { version = "0.15", default-features = false, features = [
   "bevy_debug_stepping",


### PR DESCRIPTION
This error broke all Android builds that added plugin `SeedlingPlugin` into bevy ECS. At bevy app initialization on Android, the dynamic linker can't find `__cxa_pure_virtual`, a symbol that is referenced by the bevy game when the seedling plugin is added. The symbol serves to handle situations when declared but not implemented C++ functions are somehow invoked (as far as I've understood).

The issue is, very few developers enable android bevy feature `android_shared_stdcxx`, that implements a C++ runtime, necessary for `__cxa_pure_virtual`, so this issue occurs. And while being quite impossible to debug without researches or knowledge about C++, I felt like I have to make this PR and not just import the feature locally.

To be clear, this feature is **always** needed by `bevy_seedling` on Android, whatever features is enabled or disabled.