### PR TITLE
v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.4.2
+
+## Fixes
+
+- The default `OnComplete` behavior in `PlaybackSettings` is now `OnComplete::Despawn`, matching the documentation
+- The `Sampler` component now properly fetches the `SamplerNode` state
+- The `head` and `tail` methods on `ConnectCommands` now return the correct entities following a `chain_node` call on `EntityCommands`
+
 # 0.4.1
 
 ## Features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_seedling"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 rust-version = "1.85.0"
 license = "MIT OR Apache-2.0"

--- a/src/edge/connect.rs
+++ b/src/edge/connect.rs
@@ -264,7 +264,7 @@ impl<'a> Connect<'a> for EntityCommands<'a> {
         let new_id = self.commands().spawn(node).id();
 
         let mut new_connection = self.connect_with(new_id, ports);
-        new_connection.head = new_id;
+        new_connection.tail = Some(new_id);
 
         new_connection
     }

--- a/src/sample/mod.rs
+++ b/src/sample/mod.rs
@@ -429,7 +429,7 @@ impl Default for PlaybackSettings {
             playback: Notify::new(PlaybackState::Play { delay: None }),
             playhead: Notify::default(),
             speed: 1.0,
-            on_complete: OnComplete::Remove,
+            on_complete: OnComplete::Despawn,
         }
     }
 }


### PR DESCRIPTION
## Fixes

- The default `OnComplete` behavior in `PlaybackSettings` is now `OnComplete::Despawn`, matching the documentation
- The `Sampler` component now properly fetches the `SamplerNode` state
- The `head` and `tail` methods on `ConnectCommands` now return the correct entities following a `chain_node` call on `EntityCommands`