### PR TITLE
Add `Sample::new`

### DIFF
--- a/src/sample/assets.rs
+++ b/src/sample/assets.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 pub struct Sample(ArcGc<dyn SampleResource>);
 
 impl Sample {
-    /// Create a new `Sample` from a `SampleResource` loaded into memory.
+    /// Create a new [`Sample`] from a [`SampleResource`] loaded into memory.
     pub fn new<S: SampleResource>(sample: S) -> Self {
         Self(ArcGc::new_unsized(|| Arc::new(sample) as _))
     }

--- a/src/sample/assets.rs
+++ b/src/sample/assets.rs
@@ -15,6 +15,11 @@ use std::sync::Arc;
 pub struct Sample(ArcGc<dyn SampleResource>);
 
 impl Sample {
+    /// Create a new `Sample` from a `SampleResource` loaded into memory.
+    pub fn new<S: SampleResource>(sample: S) -> Self {
+        Self(ArcGc::new_unsized(|| Arc::new(sample) as _))
+    }
+
     /// Share the inner value.
     pub fn get(&self) -> ArcGc<dyn SampleResource> {
         self.0.clone()


### PR DESCRIPTION
When creating samples programmatically it is useful to be able to create a `Sample` in-memory for use with [`AssetServer::add`](https://docs.rs/bevy/latest/bevy/asset/struct.AssetServer.html#method.add). This PR adds this method to `Sample`.