### PR TITLE
Improve 3D Spatialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
+# 0.4.4
+
+## Fixes
+
+- Account for 3D listener orientation
+- Fixed system ordering issue for spatial positioning
+
 # 0.4.3
 
 ## Fixes
 
-- Update `symphonium` to match `firewheel` due to a breaking change in the former
+- Updated `symphonium` to match `firewheel` due to a breaking change in the former
 
 # 0.4.2
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_seedling"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2024"
 rust-version = "1.85.0"
 license = "MIT OR Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -309,7 +309,7 @@ pub mod prelude {
     };
 
     pub use firewheel::{
-        FirewheelConfig, Volume,
+        self, FirewheelConfig, Volume,
         channel_config::ChannelCount,
         clock::{ClockSamples, ClockSeconds},
         diff::{Memo, Notify},
@@ -438,19 +438,20 @@ where
         .add_systems(
             Last,
             (
-                (
-                    spatial::update_2d_emitters,
-                    spatial::update_2d_emitters_effects,
-                    spatial::update_3d_emitters,
-                    spatial::update_3d_emitters_effects,
-                )
-                    .before(SeedlingSystems::Acquire),
                 edge::auto_connect
                     .before(SeedlingSystems::Connect)
                     .after(SeedlingSystems::Acquire),
                 (edge::process_connections, edge::process_disconnections)
                     .chain()
                     .in_set(SeedlingSystems::Connect),
+                (
+                    spatial::update_2d_emitters,
+                    spatial::update_2d_emitters_effects,
+                    spatial::update_3d_emitters,
+                    spatial::update_3d_emitters_effects,
+                )
+                    .after(SeedlingSystems::Pool)
+                    .before(SeedlingSystems::Queue),
                 node::flush_events.in_set(SeedlingSystems::Flush),
             ),
         )
@@ -491,6 +492,7 @@ mod test {
                 spawn_default_pool: false,
                 ..SeedlingPlugin::<crate::profiling::ProfilingBackend>::new()
             },
+            TransformPlugin,
         ))
         .add_systems(Startup, startup);
 

--- a/src/spatial.rs
+++ b/src/spatial.rs
@@ -142,20 +142,19 @@ pub(crate) fn update_2d_emitters(
         let emitter_pos = transform.translation();
         let closest_listener = find_closest_listener(
             emitter_pos,
-            listeners.iter().map(GlobalTransform::translation),
+            listeners.iter().map(GlobalTransform::compute_transform),
         );
 
-        let Some(listener_pos) = closest_listener else {
+        let Some(listener) = closest_listener else {
             continue;
         };
 
         let scale = scale.map(|s| s.0).unwrap_or(default_scale.0.0);
 
-        let x_diff = (emitter_pos.x - listener_pos.x) * scale.x;
-        let y_diff = (emitter_pos.y - listener_pos.y) * scale.y;
-
-        spatial.offset.x = x_diff;
-        spatial.offset.z = y_diff;
+        let mut world_offset = emitter_pos - listener.translation;
+        world_offset.z = 0.0;
+        let local_offset = (listener.rotation.inverse() * world_offset) * scale;
+        spatial.offset = Vec3::new(local_offset.x, 0.0, local_offset.y);
     }
 }
 
@@ -174,20 +173,19 @@ pub(crate) fn update_2d_emitters_effects(
         let emitter_pos = transform.translation();
         let closest_listener = find_closest_listener(
             emitter_pos,
-            listeners.iter().map(GlobalTransform::translation),
+            listeners.iter().map(GlobalTransform::compute_transform),
         );
 
-        let Some(listener_pos) = closest_listener else {
+        let Some(listener) = closest_listener else {
             continue;
         };
 
         let scale = scale.map(|s| s.0).unwrap_or(default_scale.0.0);
 
-        let x_diff = (emitter_pos.x - listener_pos.x) * scale.x;
-        let y_diff = (emitter_pos.y - listener_pos.y) * scale.y;
-
-        spatial.offset.x = x_diff;
-        spatial.offset.z = y_diff;
+        let mut world_offset = emitter_pos - listener.translation;
+        world_offset.z = 0.0;
+        let local_offset = (listener.rotation.inverse() * world_offset) * scale;
+        spatial.offset = Vec3::new(local_offset.x, 0.0, local_offset.y);
     }
 }
 
@@ -204,16 +202,18 @@ pub(crate) fn update_3d_emitters(
         let emitter_pos = transform.translation();
         let closest_listener = find_closest_listener(
             emitter_pos,
-            listeners.iter().map(GlobalTransform::translation),
+            listeners.iter().map(GlobalTransform::compute_transform),
         );
 
-        let Some(listener_pos) = closest_listener else {
+        let Some(listener) = closest_listener else {
             continue;
         };
 
         let scale = scale.map(|s| s.0).unwrap_or(default_scale.0.0);
 
-        spatial.offset = (emitter_pos - listener_pos) * scale;
+        let world_offset = emitter_pos - listener.translation;
+        let local_offset = listener.rotation.inverse() * world_offset;
+        spatial.offset = local_offset * scale;
     }
 }
 
@@ -231,31 +231,37 @@ pub(crate) fn update_3d_emitters_effects(
         let emitter_pos = transform.translation();
         let closest_listener = find_closest_listener(
             emitter_pos,
-            listeners.iter().map(GlobalTransform::translation),
+            listeners.iter().map(GlobalTransform::compute_transform),
         );
 
-        let Some(listener_pos) = closest_listener else {
+        let Some(listener) = closest_listener else {
             continue;
         };
 
         let scale = scale.map(|s| s.0).unwrap_or(default_scale.0.0);
 
-        spatial.offset = (emitter_pos - listener_pos) * scale;
+        let world_offset = emitter_pos - listener.translation;
+        let local_offset = listener.rotation.inverse() * world_offset;
+        spatial.offset = local_offset * scale;
     }
 }
 
-fn find_closest_listener(emitter_pos: Vec3, listeners: impl Iterator<Item = Vec3>) -> Option<Vec3> {
-    let mut closest_listener: Option<(f32, Vec3)> = None;
+fn find_closest_listener(
+    emitter_pos: Vec3,
+    listeners: impl Iterator<Item = Transform>,
+) -> Option<Transform> {
+    let mut closest_listener: Option<(f32, Transform)> = None;
 
-    for listener_pos in listeners {
+    for listener in listeners {
+        let listener_pos = listener.translation;
         let distance = emitter_pos.distance_squared(listener_pos);
 
         match &mut closest_listener {
-            None => closest_listener = Some((distance, listener_pos)),
-            Some((old_distance, old_pos)) => {
+            None => closest_listener = Some((distance, listener)),
+            Some((old_distance, old_transform)) => {
                 if distance < *old_distance {
                     *old_distance = distance;
-                    *old_pos = listener_pos;
+                    *old_transform = listener;
                 }
             }
         }
@@ -267,10 +273,18 @@ fn find_closest_listener(emitter_pos: Vec3, listeners: impl Iterator<Item = Vec3
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::{
+        node::follower::FollowerOf,
+        prelude::*,
+        test::{prepare_app, run},
+    };
 
     #[test]
     fn test_closest() {
-        let positions = [Vec3::splat(5.0), Vec3::splat(4.0), Vec3::splat(6.0)];
+        let positions = [Vec3::splat(5.0), Vec3::splat(4.0), Vec3::splat(6.0)]
+            .into_iter()
+            .map(Transform::from_translation)
+            .collect::<Vec<_>>();
         let emitter = Vec3::splat(0.0);
         let closest = find_closest_listener(emitter, positions.iter().copied()).unwrap();
 
@@ -285,5 +299,40 @@ mod test {
         let closest = find_closest_listener(emitter, positions.iter().copied());
 
         assert!(closest.is_none());
+    }
+
+    #[derive(PoolLabel, PartialEq, Eq, Hash, Clone, Debug)]
+    struct TestPool;
+
+    /// Ensure that transform updates are propagated immediately when
+    /// queued in a pool.
+    #[test]
+    fn test_immediate_positioning() {
+        let position = Vec3::splat(3.0);
+        let mut app = prepare_app(move |mut commands: Commands, server: Res<AssetServer>| {
+            commands.spawn((
+                SamplerPool(TestPool),
+                sample_effects![SpatialBasicNode::default()],
+            ));
+
+            commands.spawn((SpatialListener3D, Transform::default()));
+
+            commands.spawn((
+                TestPool,
+                Transform::from_translation(position),
+                SamplePlayer::new(server.load("sine_440hz_1ms.wav")),
+            ));
+        });
+
+        // NOTE: why is this update necessary? shouldn't it be ready immediately?
+        app.update();
+
+        run(
+            &mut app,
+            move |effect: Query<&SpatialBasicNode, With<FollowerOf>>| {
+                let effect = effect.single().unwrap();
+                assert_eq!(effect.offset, position);
+            },
+        );
     }
 }


### PR DESCRIPTION
There are two main issues with 3D spatialization right now:

1. We don't take the orientation of the listener into account.
2. Almost randomly, sounds may start playing with a spatial offset of `(0, 0, 0)`.

This PR resolves both these issues. The first simply needed implementing. The second was caused by suboptimal system scheduling.