### PR TITLE
Make `TimePlugin` public

### DIFF
--- a/src/time.rs
+++ b/src/time.rs
@@ -35,7 +35,9 @@ use std::time::Duration;
 
 use crate::context::AudioContext;
 
-pub(crate) struct TimePlugin;
+/// Plugin that configures the [`Time<Audio>`] resource.
+#[derive(Debug)]
+pub struct TimePlugin;
 
 impl Plugin for TimePlugin {
     fn build(&self, app: &mut App) {


### PR DESCRIPTION
I'm working on a plugin that is dependent on the `SeedlingPlugin`.

Since `SeedlingPlugin` has a generic `T`, I need to be able to know if its sub-plugins have been added already. i.e.
```rust
impl Plugin for SynthPlugin {
    fn build(&self, app: &mut App) {
        if !app.is_plugin_added::<TimePlugin>() {
            app.add_plugins(TimePlugin);
        }
    }
   ...
}
```

I can't know which `AudioBackend` they use, hence
```rust
    fn build(&self, app: &mut App) {
        if !app.is_plugin_added::<SeedlingPlugin<???>>() {
            app.add_plugins(SeedlingPlugin::new());
        }
    }
    ..
````
won't work unless I also include a generic on my plugin, which is undesirable.
