### PR TITLE
gate location diagnostics behind feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,9 @@ rand = ["dep:rand"]
 reflect = ["firewheel/bevy_reflect", "firewheel-ircam-hrtf?/bevy_reflect"]
 cpal = ["firewheel/cpal", "dep:cpal"]
 web_audio = ["cpal/audioworklet"]
-dev = ["entity_names"]
+dev = ["entity_names", "track_location"]
 entity_names = []
+track_location = []
 symphonia = [
   "dep:symphonia",
   "dep:symphonium",

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ should help you get up to speed on common usage patterns.
 | `resample_inputs` | Enable audio input resampling.             | No      |
 | `dev`             | Enable helpful features for development.   | No      |
 | `entity_names`    | Add `Name`s to node and sample entities.   | No      |
+| `track_location`  | Track caller locations in diagnostics.     | No      |
 
 ## Bevy version compatibility
 

--- a/src/edge/connect.rs
+++ b/src/edge/connect.rs
@@ -7,7 +7,7 @@ use crate::{
 use bevy_ecs::prelude::*;
 use bevy_log::prelude::*;
 
-#[cfg(debug_assertions)]
+#[cfg(feature = "track_location")]
 use core::panic::Location;
 
 /// The set of all pending connections for an entity.
@@ -198,14 +198,14 @@ pub trait Connect<'a>: Sized {
     ///
     /// The connection is deferred, finalizing in the
     /// [`SeedlingSystems::Connect`][crate::SeedlingSystems::Connect] set.
-    #[cfg_attr(debug_assertions, track_caller)]
+    #[cfg_attr(feature = "track_location", track_caller)]
     fn connect(self, target: impl Into<EdgeTarget>) -> ConnectCommands<'a>;
 
     /// Queue a connection from this entity to the target with the provided port mappings.
     ///
     /// The connection is deferred, finalizing in the
     /// [`SeedlingSystems::Connect`][crate::SeedlingSystems::Connect] set.
-    #[cfg_attr(debug_assertions, track_caller)]
+    #[cfg_attr(feature = "track_location", track_caller)]
     fn connect_with(
         self,
         target: impl Into<EdgeTarget>,
@@ -226,14 +226,14 @@ pub trait Connect<'a>: Sized {
     ///     .chain_node(VolumeNode::default());
     /// # }
     /// ```
-    #[cfg_attr(debug_assertions, track_caller)]
+    #[cfg_attr(feature = "track_location", track_caller)]
     fn chain_node<B: Bundle>(self, node: B) -> ConnectCommands<'a>;
 
     /// Chain a node with a manually-specified connection.
     ///
     /// This connection will be made between the previous node's output
     /// and this node's input.
-    #[cfg_attr(debug_assertions, track_caller)]
+    #[cfg_attr(feature = "track_location", track_caller)]
     fn chain_node_with<B: Bundle>(self, node: B, ports: &[(u32, u32)]) -> ConnectCommands<'a>;
 
     /// Get the head of this chain.
@@ -268,13 +268,13 @@ pub trait Connect<'a>: Sized {
     fn tail(&self) -> Entity;
 }
 
-#[cfg_attr(debug_assertions, track_caller)]
+#[cfg_attr(feature = "track_location", track_caller)]
 fn connect_with_commands(
     target: EdgeTarget,
     connections: Option<Vec<(u32, u32)>>,
     commands: &mut EntityCommands,
 ) {
-    #[cfg(debug_assertions)]
+    #[cfg(feature = "track_location")]
     let location = Location::caller();
 
     commands
@@ -284,7 +284,7 @@ fn connect_with_commands(
             pending.push(PendingEdge::new_with_location(
                 target,
                 connections,
-                #[cfg(debug_assertions)]
+                #[cfg(feature = "track_location")]
                 location,
             ));
         });
@@ -340,7 +340,7 @@ impl<'a> Connect<'a> for EntityCommands<'a> {
 }
 
 impl<'a> Connect<'a> for ConnectCommands<'a> {
-    #[cfg_attr(debug_assertions, track_caller)]
+    #[cfg_attr(feature = "track_location", track_caller)]
     fn connect(mut self, target: impl Into<EdgeTarget>) -> ConnectCommands<'a> {
         let tail = self.tail();
 
@@ -354,7 +354,7 @@ impl<'a> Connect<'a> for ConnectCommands<'a> {
         self
     }
 
-    #[cfg_attr(debug_assertions, track_caller)]
+    #[cfg_attr(feature = "track_location", track_caller)]
     fn connect_with(
         mut self,
         target: impl Into<EdgeTarget>,

--- a/src/edge/disconnect.rs
+++ b/src/edge/disconnect.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use bevy_ecs::prelude::*;
 
-#[cfg(debug_assertions)]
+#[cfg(feature = "track_location")]
 use core::panic::Location;
 
 /// The set of all pending disconnections for an entity.
@@ -86,24 +86,24 @@ pub trait Disconnect: Sized {
     ///
     /// The disconnection is deferred, finalizing in the
     /// [`SeedlingSystems::Connect`][crate::SeedlingSystems::Connect] set.
-    #[cfg_attr(debug_assertions, track_caller)]
+    #[cfg_attr(feature = "track_location", track_caller)]
     fn disconnect(self, target: impl Into<EdgeTarget>) -> Self;
 
     /// Queue a disconnection from this entity to the target with the provided port mappings.
     ///
     /// The disconnection is deferred, finalizing in the
     /// [`SeedlingSystems::Connect`][crate::SeedlingSystems::Connect] set.
-    #[cfg_attr(debug_assertions, track_caller)]
+    #[cfg_attr(feature = "track_location", track_caller)]
     fn disconnect_with(self, target: impl Into<EdgeTarget>, ports: &[(u32, u32)]) -> Self;
 }
 
-#[cfg_attr(debug_assertions, track_caller)]
+#[cfg_attr(feature = "track_location", track_caller)]
 fn disconnect_with_commands(
     target: EdgeTarget,
     ports: Option<Vec<(u32, u32)>>,
     commands: &mut EntityCommands,
 ) {
-    #[cfg(debug_assertions)]
+    #[cfg(feature = "track_location")]
     let location = Location::caller();
 
     commands
@@ -113,7 +113,7 @@ fn disconnect_with_commands(
             pending.push(PendingEdge::new_with_location(
                 target,
                 ports,
-                #[cfg(debug_assertions)]
+                #[cfg(feature = "track_location")]
                 location,
             ));
         });

--- a/src/edge/mod.rs
+++ b/src/edge/mod.rs
@@ -12,7 +12,7 @@ use bevy_platform::collections::HashMap;
 use firewheel::FirewheelContext;
 use firewheel::node::NodeID;
 
-#[cfg(debug_assertions)]
+#[cfg(feature = "track_location")]
 use core::panic::Location;
 
 #[allow(clippy::module_inception)]
@@ -195,18 +195,18 @@ pub struct PendingEdge {
     /// `[(0, 0), (1, 1)]` is used.
     pub ports: Option<Vec<(u32, u32)>>,
 
-    #[cfg(debug_assertions)]
+    #[cfg(feature = "track_location")]
     pub(crate) origin: &'static Location<'static>,
 }
 
 impl PendingEdge {
     /// Construct a new [`PendingEdge`].
-    #[cfg_attr(debug_assertions, track_caller)]
+    #[cfg_attr(feature = "track_location", track_caller)]
     pub fn new(target: impl Into<EdgeTarget>, ports: Option<Vec<(u32, u32)>>) -> Self {
         Self {
             target: target.into(),
             ports,
-            #[cfg(debug_assertions)]
+            #[cfg(feature = "track_location")]
             origin: Location::caller(),
         }
     }
@@ -215,12 +215,12 @@ impl PendingEdge {
     fn new_with_location(
         target: impl Into<EdgeTarget>,
         ports: Option<Vec<(u32, u32)>>,
-        #[cfg(debug_assertions)] location: &'static Location<'static>,
+        #[cfg(feature = "track_location")] location: &'static Location<'static>,
     ) -> Self {
         Self {
             target: target.into(),
             ports,
-            #[cfg(debug_assertions)]
+            #[cfg(feature = "track_location")]
             origin: location,
         }
     }
@@ -307,14 +307,14 @@ fn lookup_node<'a>(
     match targets.get(target_entity) {
         Ok(t) => Some(t),
         Err(_) => {
-            #[cfg(debug_assertions)]
+            #[cfg(feature = "track_location")]
             {
                 let location = connection.origin;
                 error_once!(
                     "failed to connect to entity `{target_entity:?}` at {location}: no Firewheel node found"
                 );
             }
-            #[cfg(not(debug_assertions))]
+            #[cfg(not(feature = "track_location"))]
             {
                 let _ = connection;
                 error_once!(
@@ -339,14 +339,14 @@ fn fetch_target(
         }
         EdgeTarget::Label(label) => {
             let Some(entity) = node_map.get(&label) else {
-                #[cfg(debug_assertions)]
+                #[cfg(feature = "track_location")]
                 {
                     let location = connection.origin;
                     error_once!(
                         "failed to connect to node label `{label:?}` at {location}: no associated Firewheel node found"
                     );
                 }
-                #[cfg(not(debug_assertions))]
+                #[cfg(not(feature = "track_location"))]
                 error_once!(
                     "failed to connect to node label `{label:?}`: no associated Firewheel node found"
                 );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,6 +144,7 @@
 //! | `resample_inputs` | Enable audio input resampling.             | No      |
 //! | `dev`             | Enable helpful features for development.   | No      |
 //! | `entity_names`    | Add [`Name`]s to node and sample entities. | No      |
+//! | `track_location`  | Track caller locations in diagnostics.     | No      |
 //!
 //! [`RandomPitch`]: crate::prelude::RandomPitch
 //! [`Name`]: bevy_ecs::prelude::Name

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -584,7 +584,7 @@ pub trait RegisterNode {
 }
 
 impl RegisterNode for App {
-    #[cfg_attr(debug_assertions, track_caller)]
+    #[cfg_attr(feature = "track_location", track_caller)]
     fn register_node<T>(&mut self) -> &mut Self
     where
         T: AudioNode<Configuration: Component + Clone + PartialEq>
@@ -602,7 +602,7 @@ impl RegisterNode for App {
         } else {
             // TODO: we'll need to be more careful about getting type names
             // for upstreaming.
-            #[cfg(debug_assertions)]
+            #[cfg(feature = "track_location")]
             {
                 bevy_log::warn!(
                     "Audio node `{}` was registered more than once at {}",
@@ -611,7 +611,7 @@ impl RegisterNode for App {
                 );
             }
 
-            #[cfg(not(debug_assertions))]
+            #[cfg(not(feature = "track_location"))]
             bevy_log::warn!(
                 "Audio node `{}` was registered more than once",
                 core::any::type_name::<T>(),
@@ -640,7 +640,7 @@ impl RegisterNode for App {
         )
     }
 
-    #[cfg_attr(debug_assertions, track_caller)]
+    #[cfg_attr(feature = "track_location", track_caller)]
     fn register_simple_node<T>(&mut self) -> &mut Self
     where
         T: AudioNode<Configuration: Component + Clone + PartialEq> + Component + Clone,
@@ -652,7 +652,7 @@ impl RegisterNode for App {
             world.add_observer(observe_simple_node_insertion::<T>);
             world.register_required_components::<T, T::Configuration>();
         } else {
-            #[cfg(debug_assertions)]
+            #[cfg(feature = "track_location")]
             {
                 bevy_log::warn!(
                     "Audio node `{}` was registered more than once at {}",
@@ -661,7 +661,7 @@ impl RegisterNode for App {
                 );
             }
 
-            #[cfg(not(debug_assertions))]
+            #[cfg(not(feature = "track_location"))]
             bevy_log::warn!(
                 "Audio node `{}` was registered more than once",
                 core::any::type_name::<T>(),
@@ -685,7 +685,7 @@ impl RegisterNode for App {
         )
     }
 
-    #[cfg_attr(debug_assertions, track_caller)]
+    #[cfg_attr(feature = "track_location", track_caller)]
     fn register_node_state<T, S>(&mut self) -> &mut Self
     where
         T: AudioNode + Component,
@@ -695,7 +695,7 @@ impl RegisterNode for App {
         let mut nodes = world.get_resource_or_init::<RegisteredState>();
 
         if !nodes.insert::<T, S>() {
-            #[cfg(debug_assertions)]
+            #[cfg(feature = "track_location")]
             {
                 bevy_log::warn!(
                     "State `{}` was registered for node `{}` at {}",
@@ -705,7 +705,7 @@ impl RegisterNode for App {
                 );
             }
 
-            #[cfg(not(debug_assertions))]
+            #[cfg(not(feature = "track_location"))]
             bevy_log::warn!(
                 "State `{}` registered more than once for node `{}`",
                 core::any::type_name::<S>(),


### PR DESCRIPTION
 adds a `location_tracking` feature for caller-location diagnostics
 
 changes
  > - add `location_tracking`
  > - enable it through `dev`
  > - gate edge caller locations on `location_tracking` instead of `debug_assertions`
  > - include caller locations in duplicate node/state registration diagnostics
  > - document the new feature flag