### PR TITLE
Upgrade to rand v0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,9 +88,8 @@ symphonium = { version = "0.9", default-features = false, features = [
 symphonia = { version = "0.5", default-features = false, optional = true }
 smallvec = { version = "1.13", default-features = false }
 bevy_seedling_macros = { path = "./seedling_macros", version = "0.7.0" }
-rand = { version = "0.9", default-features = false, features = [
-  "small_rng",
-  "os_rng",
+rand = { version = "0.10", default-features = false, features = [
+  "sys_rng",
 ], optional = true }
 ebur128 = { version = "0.1.10", optional = true }
 portable-atomic = { version = "1.11", optional = true, features = ["float"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,7 +136,7 @@ criterion = { version = "0.5", default-features = false, features = [
 audioadapter-buffers = { version = "3.0", default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-getrandom = { version = "0.3", default-features = false, features = [
+getrandom = { version = "0.4", default-features = false, features = [
   "wasm_js",
 ] }
 

--- a/src/sample/mod.rs
+++ b/src/sample/mod.rs
@@ -697,13 +697,19 @@ mod random {
     use super::PlaybackSettings;
     use bevy_app::prelude::*;
     use bevy_ecs::prelude::*;
-    use rand::{SeedableRng, rngs::SmallRng};
+    use rand::{
+        RngExt, SeedableRng,
+        rand_core::UnwrapErr,
+        rngs::{SmallRng, SysRng},
+    };
 
     pub struct RandomPlugin;
 
     impl Plugin for RandomPlugin {
         fn build(&self, app: &mut App) {
-            app.insert_resource(PitchRngSource::new(SmallRng::from_os_rng()))
+            let mut sys_rng = UnwrapErr(SysRng);
+
+            app.insert_resource(PitchRngSource::new(SmallRng::from_rng(&mut sys_rng)))
                 .add_systems(Last, RandomPitch::apply.before(SeedlingSystems::Acquire));
         }
     }


### PR DESCRIPTION
Does what it says on the tin. The changes needed is to remove the `small-rng` feature flag as it is no longer needed to access the `SmallRng` struct, and `os_rng` has been renamed to `sys_rng`. To initialise the PitchRngSource, I've had to include a bit of ceremony to load a `SysRng` which only implements `TryRng`, to unwrap & panic on failure so that it implements `Rng`, allowing it to initialise `SmallRng` from the `from_rng` method.

This PR can be merged later once the upgrade to v0.19 is done, as that version is the one that moves to rand v0.10.