### PR TITLE
Snap `HrtfNode`'s smoothers when a reused slot restarts

### DIFF
--- a/crates/firewheel-ircam-hrtf/CHANGELOG.md
+++ b/crates/firewheel-ircam-hrtf/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Unreleased
+
+## Fixes
+
+- `HrtfNode` no longer starts a reused pool slot at the previous occupant's gain
+  and direction, matching `SpatialBasicNode`'s settled-silence snap.
+
 # 0.5.0
 
 # Changes

--- a/crates/firewheel-ircam-hrtf/src/lib.rs
+++ b/crates/firewheel-ircam-hrtf/src/lib.rs
@@ -271,6 +271,7 @@ impl AudioNode for HrtfNode {
             prev_right_samples: Vec::with_capacity(fft_buffer_len),
             sphere_source: config.hrir_sphere.clone(),
             fft_size: config.fft_size.clone(),
+            prev_input_settled: true,
         })
     }
 }
@@ -289,13 +290,37 @@ struct FyroxHrtfProcessor {
     prev_right_samples: Vec<f32>,
     sphere_source: HrirSource,
     fft_size: FftSize,
+    prev_input_settled: bool,
+}
+
+impl FyroxHrtfProcessor {
+    /// Reset the smoothers and convolution state so the next signal starts from
+    /// silence instead of interpolating out of the previous one. Needed when the
+    /// node is reused, as in a sampler pool.
+    fn reset(&mut self) {
+        self.attenuation_processor.reset();
+        self.previous_offset = self.offset;
+        // Cleared rather than zeroed, since the FFT fires once `fft_input` is full
+        // and `fft_output` is drained a block at a time.
+        self.fft_input.clear();
+        self.fft_output.clear();
+
+        // Zeroed in place rather than cleared, since `hrtf` reallocates these
+        // when their length changes and this runs on the audio thread.
+        self.prev_left_samples.fill(0.0);
+        self.prev_right_samples.fill(0.0);
+    }
 }
 
 impl AudioNodeProcessor for FyroxHrtfProcessor {
     fn events(&mut self, info: &ProcInfo, events: &mut ProcEvents, _extra: &mut ProcExtra) {
+        let mut offset_updated = false;
+
         for patch in events.drain_patches::<HrtfNode>() {
             match patch {
                 HrtfNodePatch::Offset(offset) => {
+                    offset_updated = true;
+
                     let distance = offset.length().max(0.01);
 
                     self.attenuation_processor.compute_values(
@@ -325,19 +350,37 @@ impl AudioNodeProcessor for FyroxHrtfProcessor {
                 }
             }
         }
+
+        // The previous block's input settled at zero, so no need to smooth. Only
+        // the offset affects gain and direction, so other patches are left alone.
+        if offset_updated && self.prev_input_settled {
+            self.reset();
+        }
     }
 
     fn process(
         &mut self,
         proc_info: &ProcInfo,
-        ProcBuffers { inputs, outputs }: ProcBuffers,
+        buffers: ProcBuffers,
         _: &mut ProcExtra,
     ) -> ProcessStatus {
-        if proc_info.in_silence_mask.all_channels_silent(inputs.len()) {
-            self.attenuation_processor.reset();
+        if proc_info
+            .in_silence_mask
+            .all_channels_silent(buffers.inputs.len())
+        {
+            // All channels are silent, so there is no need to process. Reset once
+            // on the way in, since after that there is nothing left to flush.
+            if !self.prev_input_settled {
+                self.reset();
+            }
+            self.prev_input_settled = true;
 
             return ProcessStatus::ClearAllOutputs;
         }
+
+        self.prev_input_settled = buffers.inputs_settled_at_zero();
+
+        let ProcBuffers { inputs, outputs } = buffers;
 
         for frame in 0..proc_info.frames {
             let mut downmixed = 0.0;


### PR DESCRIPTION
Fixes #127.

`HrtfNode` opens a reused pool slot at the previous occupant's gain and direction. `SpatialBasicNode` already handles this; the HRTF node was missing the equivalent, which is why only the HRTF tier was affected.

## The problem

The distance gain is smoothed over `smooth_seconds`, and setting a new value only moves the smoother's *target* — the filter still ramps from whatever it held. In a sampler pool "whatever it held" is the previous occupant's value, so a voice starting far away opens near the previous voice's level and slides down over the smoothing window.

Measured with a headless harness that drives the processor block by block (settle at 2 m → silence → restart at 600 m):

| | first processed block @600 m | settled @600 m |
|---|---|---|
| stock | **−14.4 dBFS** | −62.7 dBFS |
| patched | −62.3 dBFS | −62.7 dBFS |

48 dB hot, at point-blank level, on the first block of a distant sound.

`SpatialBasicNode` was exact in the same test, which is what pointed at the missing snap: it resets its smoothers when parameters change after settled input (`prev_input_settled` in its `events()`), and `HrtfNode` had no equivalent.

## The fix

Track `prev_input_settled` the same way `VolumeNode` and `SpatialBasicNode` do, and snap when an offset patch lands after settled silence.

A convolving node carries more than a gain across the gap, so the reset also clears:

- `previous_offset` — each block interpolates direction from it, so a stale one sweeps the first block across an arbitrary arc of the sphere
- `prev_left_samples` / `prev_right_samples` — the overlap-save tail is literally the previous voice's last samples
- `fft_input` / `fft_output` — a partly-accumulated input block and pending output belonging to the previous voice

Those two pairs are reset differently on purpose. The overlap-save tails are zeroed **in place**, because `hrtf::copy_replace` does `*prev_samples = vec![0.0; segment_len]` whenever the length doesn't match — clearing them would allocate on the audio thread. The FFT buffers are cleared, because there their length *is* state (the FFT fires once `fft_input` is full, and `fft_output` is drained a block at a time).

## Two things worth a reviewer's attention

**The silent path resets only on the transition into silence**, where `VolumeNode` resets unconditionally every silent block:

```rust
if !self.prev_input_settled {
    self.reset();
}
self.prev_input_settled = true;
```

Deliberate: flushing a convolution tail is real work, where resetting a gain smoother is free. Happy to make it unconditional if you'd rather it match exactly.

**Only `Offset` triggers the reset**, not every patch. It's the one arm that calls `compute_values`, so it's the only patch that changes the gain or direction this guards. That keeps an unrelated `SmoothSeconds` or `MinGain` patch from clearing FFT buffers on the audio thread.

That leaves a question I didn't want to change unasked: `MuffleCutoffHz`, `DistanceAttenuation` and `MinGain` all mutate their fields but never call `compute_values`, so they don't take effect until the next `Offset` patch arrives. That looks like it may be its own bug, but it's pre-existing and out of scope here.

## Testing

- The harness above, swept over the scheduling slack between the offset patch and the first audio block (0, 1 and 2 idle blocks). This matters: stock self-corrects from one silent block onward, because its silence path resets the smoother once the target is already the new one. The error needs the patch and the first audio to land in the *same* block, which makes it easy to "fix" against an engine that happens to be late.
- Verified in a game, where it removed an audible pop on explosions starting in reused slots.
